### PR TITLE
Removed restore from build script as done implicitly during build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -32,15 +32,6 @@ Task("__Clean")
         CleanDirectories(buildArtifacts);
     });
 
-Task("__Restore")
-    .Does(() =>
-    {      
-        foreach (var projectFile in allProjectFiles)
-        {
-            DotNetCoreRestore(projectFile.ToString());
-        }
-    });
-
 Task("__Build")
     .Does(() =>
     {
@@ -124,7 +115,6 @@ private void PublishPackages(string source, string apiKey)
 
 Task("Build")
     .IsDependentOn("__Clean")
-    .IsDependentOn("__Restore")
     .IsDependentOn("__Build")
     .IsDependentOn("__Test")
     .IsDependentOn("__Pack");

--- a/test/CheckoutSdk.Tests/CheckoutSdk.Tests.csproj
+++ b/test/CheckoutSdk.Tests/CheckoutSdk.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.6" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.2" />


### PR DESCRIPTION
This PR optimises the build script as restore is done part of the build step implicitly.

Also removed unused package from the tests project.